### PR TITLE
Correção passagem de parâmetros entre ""

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 import sys
 import time
+import shlex
 
 from typing import List
 
@@ -188,7 +189,7 @@ def main():
                         exit = True
                         break
                     else:
-                        pars = cli_pars + user_input.split(' ')
+                        pars = cli_pars + shlex.split(user_input)
 
                         # Interpreting args
                         args, _ = parser.parse_known_args(pars)


### PR DESCRIPTION
A partir do AdminSQL, se passar os parâmetros entre "", ele fazia o split de forma incorreta, e não funcionava como deveria. Realizado a troca do modo de split para separar o texto conforme as regras de sintaxe de shell com o _shlex_.